### PR TITLE
Allow goggles to work on published thimble makes.

### DIFF
--- a/webxray/src/get-bookmarklet-url.js
+++ b/webxray/src/get-bookmarklet-url.js
@@ -13,7 +13,7 @@ var Webxray = (function() {
     getBookmarkletURL: function getBookmarkletURL(baseURI, lang) {
       baseURI = baseURI || this._getBaseURI();
 
-      var baseCode = "(function(){var script=document.createElement('script');script.src='-baseuri-/"+lang+"/webxray.js';script.className='webxray';script.setAttribute('data-lang','"+lang+"');script.setAttribute('data-baseuri','-baseuri-/"+lang+"');document.body.appendChild(script);})();";
+      var baseCode = "(function(){var doc=document;var urlParser=document.createElement('a');urlParser.href=window.location.href;if(/makes.org/.test(urlParser.host)&&/^\\/thimble\\/(.*)[^_]$/.test(urlParser.pathname)){doc=document.querySelector('iframe.embed-iframe').contentDocument;}var script=doc.createElement('script');script.src='-baseuri-/"+lang+"/webxray.js';script.className='webxray';script.setAttribute('data-lang','"+lang+"');script.setAttribute('data-baseuri','-baseuri-/"+lang+"');doc.body.appendChild(script);})();";
       var code = baseCode.replace( /-baseuri-/g, baseURI );
 
       return 'javascript:' + code;


### PR DESCRIPTION
This is one has been nagging at me for a while, so I did some quick
testing and came up with a solution ;)

What this change does is essentially chage the bookmarklet code from:

```js

	(function () {
	    var script = document.createElement('script');
	    script.src = '-baseuri-/-lang-/webxray.js';
	    script.className = 'webxray';
	    script.setAttribute('data-lang', '-lang-');
	    script.setAttribute('data-baseuri', '-baseuri-/-lang-');
	    document.body.appendChild(script);
	})();

```

To this:

```js

	(function () {
	    var doc = document;
	    var urlParser = document.createElement('a');
	    urlParser.href = window.location.href;
	    if (/makes.org/.test(urlParser.host) && /^\/thimble\/(.*)[ ^ _]$/.test(urlParser.pathname)) {
	        doc = document.querySelector('iframe.embed-iframe').contentDocument;
	    }

	    var script = doc.createElement('script');
	    script.src = '-baseuri-/-lang-/webxray.js';
	    script.className = 'webxray';
	    script.setAttribute('data-lang', '-lang-');
	    script.setAttribute('data-baseuri', '-baseuri-/-lang-');
	    doc.body.appendChild(script);
	})();

```

*Where `-baseuri-` and `-lang-` get replaced on build.*

This sets the document to be either that of the make w/i the preview
iframe if on a published thimble project ELSE keeps it as the parent
page's document.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1026484
Test regex: http://bit.ly/1i7BQ34