### PR TITLE
we need to catch localStorage access

### DIFF
--- a/webxray/src/preferences.js
+++ b/webxray/src/preferences.js
@@ -1,6 +1,11 @@
-(function(){
-  if ('webxrayPreferences' in localStorage)
-    window.parent.postMessage(localStorage.webxrayPreferences, "*");
-  else
+(function() {
+  var fallback = function() {
     window.parent.postMessage("{}", "*");
+  };
+  try {
+    if (!!localStorage["webxrayPreferences"])
+      window.parent.postMessage(localStorage.webxrayPreferences, "*");
+    else
+      fallback();
+  } catch (e) { fallback(); }
 }());


### PR DESCRIPTION
Recent FF may flag it as insecure and prevent startup due to a security throw, so we need to try/catch and fallback to an empty object if the browser forbids localStorage access