### PR TITLE
old style req.session fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,7 +171,7 @@ app.get("/", function(req, res) {
   res.render("index.html", {
     audience: env.get("audience"),
     csrf: req.csrfToken(),
-    email: req.session.email || "",
+    email: req.session.user.email || "",
     host: env.get("APP_HOSTNAME"),
     personaHost: env.get("PERSONA_HOST")
   });
@@ -188,7 +188,7 @@ app.get("/uproot-dialog.html", csp, function(req, res) {
   res.render("uproot-dialog.html", {
     audience: env.get("audience"),
     csrf: req.csrfToken(),
-    email: req.session.email || "",
+    email: req.session.user.email || "",
     personaHost: env.get("PERSONA_HOST")
   });
 });
@@ -199,7 +199,7 @@ app.get("/publication.js", function(req, res) {
   res.render("publication.js", {
     audience: env.get("audience"),
     csrf: req.csrfToken(),
-    email: req.session.email || ""
+    email: req.session.user.email || ""
   });
 });
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -91,14 +91,10 @@ module.exports = function middlewareConstructor(env) {
      * Check whether the requesting user is authenticated through Persona.
      */
     checkForAuth: function(req, res, next) {
-      var err;
       if (!req.session.user) {
-        err = new Error("No persona session was found, please log in first.");
+        return next(new Error("please log in first"));
       }
-      else if (!req.session.user.username) {
-        err = new Error("No username was found for " + req.session.persona + ".");
-      }
-      next(err);
+      next();
     },
 
     /**
@@ -183,7 +179,7 @@ module.exports = function middlewareConstructor(env) {
           }
 
           // We own this page, so an edit is safe.
-          if (req.body.pageOperation === "edit" && result.userid === req.session.email) {
+          if (req.body.pageOperation === "edit" && result.userid === req.session.user.email) {
             // We need to know if an edit changed the title,
             // so we can update the old project by the old url.
             if (req.body.metaData.title !== result.title) {
@@ -219,7 +215,7 @@ module.exports = function middlewareConstructor(env) {
           rawData: req.body.html,
           sanitizedData: req.body.sanitizedHTML,
           title: req.pageTitle,
-          userid: req.session.email
+          userid: req.session.user.email
         };
 
         db.write(options, function(err, result) {
@@ -241,7 +237,7 @@ module.exports = function middlewareConstructor(env) {
       return function(req, res, next) {
         var options = {
           id: req.publishId,
-          userid: req.session.email,
+          userid: req.session.user.email,
           url: req.publishedUrl
         };
         db.updateUrl(options, function(err, project) {
@@ -292,7 +288,7 @@ module.exports = function middlewareConstructor(env) {
         var edit = (req.body.pageOperation === "edit");
 
         db.count({
-          userid: req.session.email,
+          userid: req.session.user.email,
           title: req.pageTitle
         }, function(err, count) {
           if (err) {
@@ -317,10 +313,10 @@ module.exports = function middlewareConstructor(env) {
 
       return function(req, res, next) {
         var subdomain = req.session.user.username,
+            // Title count suffix, if the title is not unique:
             suffix = (req.pageTitleCount ? "-" + req.pageTitleCount : ""),
             path = "/" + appName + "/" + req.pageTitle + suffix;
 
-        // Title count suffix, if the title is not unique
         req.publishLocation = "/" + subdomain + path;
         req.s3Url = s3.url(req.publishLocation);
 
@@ -416,7 +412,7 @@ module.exports = function middlewareConstructor(env) {
               description: metaData.description || "",
               author: metaData.author || "",
               locale: metaData.locale || req.localeInfo.locale || "en_US",
-              email: req.session.email,
+              email: req.session.user.email,
               url: req.publishedUrl,
               contenturl: req.publishedUrl,
               remixedFrom: req.body.remixedFrom,
@@ -440,7 +436,7 @@ module.exports = function middlewareConstructor(env) {
         } else {
 
           make.search({
-            email: req.session.email,
+            email: req.session.user.email,
             url: req.oldUrl || req.publishedUrl
           }, function(err, results) {
             if (err) {


### PR DESCRIPTION
fixes #178, where makes were losing their `email` author information because some of the code still used the old style `req.session.email` field (which was null), rather than the new `req.session.user.email`.

This patch *should* have no more old style `req.session.[...]` values, but this needs to be double checked!